### PR TITLE
Added a way to "bypass" an ajaxForm.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# SM 15Jun12: Ignore eclipse project files
+.project
+.settings

--- a/jquery.form.js
+++ b/jquery.form.js
@@ -1,13 +1,16 @@
-/*!
+/*
  * jQuery Form Plugin
  * version: 3.09 (16-APR-2012)
  * @requires jQuery v1.3.2 or later
- *
+ * 
  * Examples and documentation at: http://malsup.com/jquery/form/
  * Project repository: https://github.com/malsup/form
  * Dual licensed under the MIT and GPL licenses:
  *    http://malsup.github.com/mit-license.txt
  *    http://malsup.github.com/gpl-license-v2.txt
+ *    
+ * SM 15Jun12: Modified doAjaxSubmit() to support data-ajaxForm-bypass on the clicked element, to skip XHR entirely.
+ *    
  */
 /*global ActiveXObject alert */
 ;(function($) {
@@ -710,13 +713,17 @@ $.fn.ajaxForm = function(options) {
 };
 
 // private event handlers    
+// SM 15Jun12: Modified to allow us to bypass an ajaxform submit on a given button click.
 function doAjaxSubmit(e) {
     /*jshint validthis:true */
     var options = e.data;
-    if (!e.isDefaultPrevented()) { // if event has been canceled, don't proceed
+    var bypassAjaxSubmit = $(this.clk).attr('data-ajaxForm-bypass') == 'true' ? true : false;
+    // if event has been canceled, don't proceed
+    if (!e.isDefaultPrevented() && !bypassAjaxSubmit) { 
         e.preventDefault();
         $(this).ajaxSubmit(options);
     }
+    return true;
 }
     
 function captureSubmittingElement(e) {


### PR DESCRIPTION
Sounds weird, but I have the use case where a user can create a new entry (e.g. a blog post), fill out a form, and, without saving that data to the db, they want to "preview" their work by clicking the "Preview" button, which will then submit with target=_blank (using formtarget and formaction attributes on the button itself).

Does that make sense? Anyway, since we use your lovely plugin for our project (http://www.mydoorstep.com/), I figured I'd push this change back.

Anyway, let me know what you think!

cheers,
Scott
